### PR TITLE
add mapping for HTTP_DISPLAYNAME

### DIFF
--- a/hc-simplesaml.php
+++ b/hc-simplesaml.php
@@ -469,6 +469,7 @@ function hcommons_set_env_saml_attributes() {
 		'Meta-displayName'  => 'HTTP_META_DISPLAYNAME',
 		'Meta-organizationName'  => 'HTTP_META_ORGANIZATIONDISPLAYNAME',
 		'Meta-organizationDisplayName'  => 'HTTP_META_ORGANIZATIONNAME',
+		'urn:oid:2.5.4.3' => 'HTTP_DISPLAYNAME',
 	];
 
 	$mapped = [];


### PR DESCRIPTION
BuddyPress syncs a user's name between WordPress and Xprofile whenever the name is changed in either. However, when a user is first registered, it is possible for the names to be out-of-sync (specifically, for the user's name to be set in WordPress but not in their profile).

This scenario is handled by hc-simplesaml.php::hcommons_sync_bp_profile. This function look's for a user's name in ```$_SERVER['HTTP_DISPLAYNAME']```, which is in turn set by hc-simplesaml.php::hcommons_set_env_saml_attributes. 

The latter function was not populating ```$_SERVER['HTTP_DISPLAYNAME']```, but instead ```$_SERVER['urn:oid:2.5.4.3']```, perhaps as a result of the switch to SimpleSAML. This PR adds a mapping from urn:oid:2.5.4.3 to HTTP_DISPLAYNAME to correct the problem.